### PR TITLE
Fix translation order

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,15 +238,15 @@
                         <h3>专业机构 | Organizations</h3>
                         <ul>
                             <li>Chair, IEEE Chengdu Young Professional Affinity Group (2016~)</li>
-                            <li>Council Member | 理事, Sichuan Institute of Artificial Intelligence | 四川省人工智能学会 (2022~)</li>
-                            <li>Expert Committee Member | 专家委员会委员, Guangxi Electronics Society | 广西电子学会 (2025~)</li>
+                            <li>理事 | Council Member, 四川省人工智能学会 | Sichuan Institute of Artificial Intelligence (2022~)</li>
+                            <li>专家委员会委员 | Expert Committee Member, 广西电子学会 | Guangxi Electronics Society (2025~)</li>
                         </ul>
                         <ul>
                             <li>Member, Institute of Electrical and Electronics Engineers</li>
                             <li>Member, Association for Computational Linguistics</li>
                             <li>Member, International Neural Network Society</li>
-                            <li>Member, Chinese Association for Artificial Intelligence | 中国人工智能学会</li>
-                            <li>Member, China Computer Federation | 中国计算机学会</li>
+                            <li>中国人工智能学会 | Member, Chinese Association for Artificial Intelligence</li>
+                            <li>中国计算机学会 | Member, China Computer Federation</li>
                         </ul>
                         <h3>会议组织 | Conference Organization</h3>
                         <ul>
@@ -270,9 +270,9 @@
                             <li>Neural Networks</li>
                             <li>Neurocomputing</li>
                             <li>International Journal of Medical Informatics</li>
-                            <li>Chinese Journal of Computers | 计算机学报</li>
-                            <li>Acta Automatica Sinica | 自动化学报</li>
-                            <li>Journal of Computer Science and Technology | 计算机科学技术学报（英文版）</li>
+                            <li>计算机学报 | Chinese Journal of Computers</li>
+                            <li>自动化学报 | Acta Automatica Sinica</li>
+                            <li>计算机科学技术学报（英文版） | Journal of Computer Science and Technology</li>
                             <li>...</li>
                         </ul>
                         <h3>会议评审 | Conference Reviewer</h3>


### PR DESCRIPTION
## Summary
- display Chinese titles before English translations in the organizations and journal sections

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68838dc8a418832c9433477d161e9e5b