### PR TITLE
Fix incorrect video link assignment

### DIFF
--- a/pub/jrnl/2025.bib
+++ b/pub/jrnl/2025.bib
@@ -18,7 +18,7 @@
   author    = {Qianyi Pan and Pei Yang and Zeao Zhang and Huawei Cai and Quan Guo},
   booktitle = {The 2025 International Joint Conference on Neural Networks (IJCNN 2025)},
   year      = {2025},
-  note      = {Accepted}
+  note      = {Accepted. [[Video](https://vimeo.com/1095993118)]}
 }
 
 @article{qingyang2025Knowledge,


### PR DESCRIPTION
## Summary
- remove video link from NavHint entry
- attach video link to the medical image segmentation paper entry

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6883a7696af0832c9ab441e9478fc64c