### PR TITLE
Update conference reviewer section

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,16 +278,17 @@
                         <h3>会议评审 | Conference Reviewer</h3>
                         <ul>
                             <li>Annual Meeting of the Association for Computational Linguistics (ACL)</li>  <!-- 2021, 2023, 2024 -->
-                            <li>AAAI Conference on Artificial Intelligence (AAAI)</li>  <!-- 2021 -->
+                            <li>AAAI Conference on Artificial Intelligence (AAAI)</li>  <!-- 2021, 2026 -->
                             <li>Conference on Empirical Methods in Natural Language Processing (EMNLP)</li>  <!-- 2020, 2023, 2024 -->
                             <li>Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)</li>  <!-- 2024, 2025 -->
-                            <li>IEEE Conference on Artificial Intelligence (CAI)</li>  <!-- 2021 -->
+                            <li>IEEE Conference on Artificial Intelligence (CAI)</li>  <!-- 2021, 2024 -->
                             <li>International Joint Conference on Neural Networks (IJCNN)</li>  <!-- 2014, 2015, 2016, 2017, 2019, 2020, 2021, 2022, 2023, 2024 -->
-                            <li>The International Conference on Acoustics, Speech, & Signal Processing (ICASSP)</li>  <!-- 2023, 2024 -->
-                            <li>ACM International Conference on Multimedia in Asia (MM Asia)</li>  <!-- 2019, 2021, 2022, 2023, 2024 -->
-                            <li>CCF International Conference on Natural Language Processing and Chinese Computing (NLPCC)</li>  <!-- 2024 -->
+                            <li>The International Conference on Acoustics, Speech, & Signal Processing (ICASSP)</li>  <!-- 2023, 2024, 2025 -->
+                            <li>ACM International Conference on Multimedia in Asia (MM Asia)</li>  <!-- 2019, 2021, 2022, 2023, 2024, 2025 -->
+                            <li>CCF International Conference on Natural Language Processing and Chinese Computing (NLPCC)</li>  <!-- 2024, 2025 -->
                             <li>National Conference of Theoretical Computer Science (NCTCS)</li>  <!-- (NCTCS 2015) Jinhua, China, Oct. 30 - Nov. 1, 2015 -->
                             <li>International Conference on Frontier of Computer Science and Technology (FCST)</li>  <!-- (FCST 2016), Nagasaki, Japan, Nov. 11, 2016 -->
+                            <li>The International Conference on Machine Intelligence and Nature-Inspired Computing (MIND)</li>  <!-- 2025 -->
                             <li>...</li>
                         </ul>
                         <h3>荣誉与获奖 | Honors &amp; Awards</h3>


### PR DESCRIPTION
## Summary
- list AAAI 2026, CAI 2024, ICASSP 2025, MM Asia 2025 and NLPCC 2025
- add The International Conference on Machine Intelligence and Nature-Inspired Computing (MIND 2025)

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887a27504cc832c840f4a8453c5daf3