### PR TITLE
Fix pr-preview branch handling

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -28,11 +28,11 @@ jobs:
         if: github.event.action != 'closed'
         run: |
           mkdir _site
-          rsync -av --exclude .git --exclude .github --exclude CNAME ./ _site/
+          rsync -av --exclude .git --exclude .github --exclude CNAME --exclude pr-preview ./ _site/
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./_site
-          preview-branch: main
+          preview-branch: pr-preview
           pages-base-url: ${{ github.repository_owner }}.github.io

--- a/README.md
+++ b/README.md
@@ -13,5 +13,7 @@ Visit [guoquan.net](https://guoquan.net) to see the website.
 
 Pull requests automatically deploy a preview version to GitHub Pages. Check the
 PR status checks for a preview URL under the `pr-preview/` path before merging.
-Previews deploy to the `main` branch using the repository’s default
-`github.io` domain instead of the custom domain.
+Previews deploy to a dedicated `pr-preview` branch using the repository’s
+default `github.io` domain instead of the custom domain.
+The preview directory is excluded from builds and is automatically
+removed when a pull request is closed.


### PR DESCRIPTION
## Summary
- deploy previews to a dedicated `pr-preview` branch instead of `main`
- update docs about the new preview branch

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68896ab9eb20832cb0d22ea376637700