### PR TITLE
Fix conference section order

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,7 @@
                         </ul>
                         <h3>会议组织 | Conference Organization</h3>
                         <ul>
+                            <li>Technical Program Committee, International Conference on SMART MULTIMEDIA 2025.</li>
                             <li>Special Session Chair and Program Committee Member, Theory and Applications of nmODE, in conjunction with <span title="the 2023 International Annual Conference on Complex Systems and Intelligent Science">CSIS-IAC 2023</span>, October 20-22, 2023, Shenzhen, China.</li>
                             <li>Program Committee Member, The First International Workshop on Combining Learning and Reasoning: Programming Languages, Formalisms, and Representations (CLeaR 2022), in conjunction with <span title="the 36th AAAI conference on artificial intelligence">AAAI 2022</span>, February 22-March 1, 2022, Vancouver, BC, Canada.</li>
                             <li>Organizing Committee, The Fourth International Workshop on Declarative Learning Based Programming (DeLBP 2019), in conjunction with the <span title="the 28th International Joint Conference on Artificial Intelligence">IJCAI-19</span>, Macao, China, Aug. 10-16, 2019.</li>


### PR DESCRIPTION
## Summary
- place SMART MULTIMEDIA 2025 service at the top of the conference organization list

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688a1494c35c832c9c7241d962d82ff8